### PR TITLE
Added find repl command

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,13 @@
       "subtitle": "Replit",
       "description": "Create a new Repl with templates for any language or framework.",
       "mode": "view"
+    },
+    {
+      "name": "findRepl",
+      "title": "Find a Repl",
+      "subtitle": "Replit",
+      "description": "Find a Repl by its name or description",
+      "mode": "view"
     }
   ],
   "dependencies": {

--- a/src/findRepl.tsx
+++ b/src/findRepl.tsx
@@ -1,0 +1,89 @@
+import { ActionPanel, Action, List, Detail } from "@raycast/api";
+import { useFetch } from "@raycast/utils";
+import { useState } from "react";
+import useConnectSid from "./hooks/useConnectSid";
+
+export default function Command() {
+  const [searchText, setSearchText] = useState("");
+
+  const connectSid = useConnectSid();
+
+  const { data, isLoading, error } = useFetch("https://replit.com/graphql", {
+    execute: searchText.length > 0,
+    parseResponse: parseFetchResponse,
+    headers: {
+      accept: "*/*",
+      "content-type": "application/json",
+      "x-requested-with": "1",
+      cookie: "connect.sid=" + connectSid,
+      origin: "https://replit.com",
+      referer: "https://replit.com/graphql",
+      "user-agent": "Raycast extension",
+    },
+    method: "POST",
+    body: JSON.stringify({
+      operationName: "ReplSearch",
+      variables: {
+        q: searchText,
+        ownerId: 987731, // TODO: query for currentUser first
+      },
+      query:
+        "query ReplSearch($q: String!, $ownerId: Int!) {\n  search(\n    options: {categories: Repls, query: $q, categorySettings: {repls: {ownerId: $ownerId}}}\n  ) {__typename\n ... on UnauthorizedError {message} \n    ... on SearchQueryResults {\n      replResults {\n        results {\n          items {\n            id\n            title\n            slug\n            description\n            iconUrl\n  url\n          }\n        }\n      }\n    }\n  }\n}\n",
+    }),
+  });
+
+  if (error) {
+    return <Detail markdown={`Error: ${error?.message}. ${error}`} />;
+  }
+
+  return (
+    <List isLoading={isLoading} onSearchTextChange={setSearchText} searchBarPlaceholder="Search repls..." throttle>
+      <List.Section title="Results" subtitle={data?.length + ""}>
+        {data?.map((searchResult: SearchResult) => (
+          <SearchListItem key={searchResult.title} searchResult={searchResult} />
+        ))}
+      </List.Section>
+    </List>
+  );
+}
+
+function SearchListItem({ searchResult }: { searchResult: SearchResult }) {
+  return (
+    <List.Item
+      title={searchResult.title}
+      subtitle={searchResult.description}
+      icon={{ source: searchResult.iconUrl }}
+      actions={
+        <ActionPanel>
+          <ActionPanel.Section>
+            <Action.OpenInBrowser title="Open in Browser" url={`https://replit.com/${searchResult.url}`} />
+          </ActionPanel.Section>
+        </ActionPanel>
+      }
+    />
+  );
+}
+
+/** Parse the response from the fetch query into something we can display */
+async function parseFetchResponse(response: Response) {
+  const res = await response.json();
+  console.log(res);
+
+  if (res?.data?.search?.replResults?.results?.items) {
+    return res.data.search.replResults.results.items.map((item: any) => ({
+      title: item.title,
+      description: item.description,
+      iconUrl: item.iconUrl,
+      url: item.url,
+    }));
+  }
+
+  return [];
+}
+
+interface SearchResult {
+  title: string;
+  description: string;
+  iconUrl: string;
+  url: string;
+}

--- a/src/hooks/useConnectSid.ts
+++ b/src/hooks/useConnectSid.ts
@@ -1,0 +1,97 @@
+import { useExec } from "@raycast/utils";
+import React from "react";
+import * as crypto from "crypto";
+
+function resolveConnectSid(connectSidHex: string, browserKeyHex: string) {
+  const encryptedValueWithoutHeader = Buffer.from(connectSidHex, "hex").slice(3);
+
+  const pass = Buffer.from(browserKeyHex, "hex");
+
+  const salt = Buffer.from("saltysalt");
+  const iv = Buffer.alloc(16, " "); // An empty initialization vector
+  const keyLength = 16;
+
+  const iterations = 1003;
+  const key = crypto.pbkdf2Sync(pass, salt, iterations, keyLength, "sha1");
+
+  const cipher = crypto.createDecipheriv("aes-128-cbc", key, iv);
+
+  const decrypted = cipher.update(encryptedValueWithoutHeader);
+  return decrypted.toString("ascii") + cipher.final("ascii");
+}
+
+function useBrowserKeyHex() {
+  const res = useExec(`security find-generic-password -s "Arc Safe Storage" -g -w`, { shell: true });
+
+  if (res.isLoading) {
+    return {
+      isLoading: true,
+    };
+  }
+
+  if (res.error) {
+    return {
+      isLoading: false,
+      error: res.error,
+    };
+  }
+
+  const browserKey = res.data;
+
+  if (!browserKey) {
+    throw new Error("No browser key found");
+  }
+
+  return {
+    isLoading: false,
+    browserKeyHex: Buffer.from(browserKey).toString("hex"),
+  };
+}
+
+function useConnectSidHex() {
+  const res = useExec(
+    `sqlite3 ~/Library/Application\\ Support/Arc/User\\ Data/Default/Cookies "select hex(encrypted_value) from cookies where host_key='replit.com' and name='connect.sid'"`,
+    { shell: true }
+  );
+
+  if (res.isLoading) {
+    return {
+      isLoading: true,
+    };
+  }
+
+  if (res.error) {
+    return {
+      isLoading: false,
+      error: res.error,
+    };
+  }
+
+  const connectSidHex = res.data;
+
+  if (!connectSidHex) {
+    return {
+      isLoading: false,
+      error: "No connect.sid found",
+    };
+  }
+
+  return {
+    isLoading: false,
+    connectSidHex: connectSidHex,
+  };
+}
+
+export default function useConnectSid() {
+  const { browserKeyHex } = useBrowserKeyHex();
+  const { connectSidHex } = useConnectSidHex();
+
+  const connectSid = React.useMemo(() => {
+    if (!connectSidHex || !browserKeyHex) {
+      return;
+    }
+    return resolveConnectSid(connectSidHex, browserKeyHex);
+  }, [connectSidHex, browserKeyHex]);
+
+  return connectSid;
+}


### PR DESCRIPTION
This adds the find repl command. To get around the authentication problem while we add a proper 3rd party auth solution, I just reused authentication that we know users are going to have

This PR queries your browser's cookie database directly to find the `connect.sid` cookie which we use for our session based authentication. But since the browser stores these cookies encrypted at rest, we also need to pull up the encryption key from keychain. This will lead to macos prompting the user for a permission, but that's okay for now. 

Once the permission is granted, we pull the browser's secret key, and decrypt the session cookie. Now we can include it with any graphql request giving us the ability to make authenticated requests as we please