### PR TITLE
Ask AI for a Template

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,16 +21,16 @@
     },
     {
       "name": "findRepl",
-      "title": "Find a Repl",
+      "title": "Search My Repls",
       "subtitle": "Replit",
       "description": "Find a Repl by its name or description",
       "mode": "view"
     },
     {
       "name": "askTemplate",
-      "title": "Ask Templates",
+      "title": "AI Template Suggestion",
       "subtitle": "Replit",
-      "description": "Ask for a template to create a Repl",
+      "description": "Describe your project idea and find a template to get started.",
       "mode": "view"
     }
   ],

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "askTemplate",
-      "title": "AI Template Suggestion",
+      "title": "AI Template Suggestion (Beta)",
       "subtitle": "Replit",
       "description": "Describe your project idea and find a template to get started.",
       "mode": "view"

--- a/package.json
+++ b/package.json
@@ -25,19 +25,26 @@
       "subtitle": "Replit",
       "description": "Find a Repl by its name or description",
       "mode": "view"
+    },
+    {
+      "name": "askTemplate",
+      "title": "Ask Templates",
+      "subtitle": "Replit",
+      "description": "Ask for a template to create a Repl",
+      "mode": "view"
     }
   ],
   "dependencies": {
     "@raycast/api": "^1.52.1",
-    "@raycast/utils": "^1.5.2"
+    "@raycast/utils": "^1.7.0"
   },
   "devDependencies": {
+    "@raycast/eslint-config": "1.0.5",
     "@types/node": "16.10.3",
     "@types/react": "18.0.9",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "eslint": "^7.32.0",
-    "@raycast/eslint-config": "1.0.5",
     "prettier": "^2.5.1",
     "react-devtools": "^4.24.6",
     "typescript": "^5.0.4"

--- a/src/askTemplate.tsx
+++ b/src/askTemplate.tsx
@@ -40,8 +40,7 @@ export default function Command() {
     isLoading: loadingKeywordResponse,
     error: keywordResponseError,
   } = useAI(
-    `
-    Your goal is to help a user choose a Replit template for a coding project. You need to infer keywords relating to their intent and the possible technologies it can be built with. Respond with a valid JSON Javascript array of five relevant search terms that may help the user find the right template according to their query intent. Do not include the word "template" in your suggested terms.
+    `Your goal is to help a user choose a Replit template for a coding project. You need to infer keywords relating to their intent and the possible technologies it can be built with. Respond with a valid JSON Javascript array of five relevant search terms that may help the user find the right template according to their query intent. Do not include the word "template" in your suggested terms.
     
     Project idea: ${searchText}.
     Example response: ["OpenAI", "Chatbot", "Python", "Data Science", "GPT-3"]
@@ -107,7 +106,7 @@ export default function Command() {
     }
 
     return <Detail markdown={markdown} />;
-  }
+  };
 
   if (keywordResponseError) {
     console.log(keywordResponseError);

--- a/src/askTemplate.tsx
+++ b/src/askTemplate.tsx
@@ -1,0 +1,90 @@
+import { Detail, List } from "@raycast/api";
+import { useAI, useFetch } from "@raycast/utils";
+import { useState } from "react";
+import useCurrentUser from "./hooks/useCurrentUser";
+
+export default function Command() {
+  const [searchText, setSearchText] = useState("");
+
+  // return <Detail isLoading={isLoading} markdown={data} />;
+
+  const {connectSid} = useCurrentUser();
+
+
+  const { data: templatesData, isLoading: loadingTemplates, error: templatesError } = useFetch("https://replit.com/graphql", {
+    // execute: searchText.length > 0,
+    parseResponse: (async response => {
+      const res = await response.json();
+      console.log(res);
+
+      if (res.data?.templateRepls2?.items) {
+        console.log(res.data.templateRepls2.items);
+        return res.data.templateRepls2.items.map((item: any) => ({
+          title: item.title,
+          id: item.id,
+          description: item.description,
+          categories: item.templateCategories.map((category: any) => category.title),
+        }));
+      }
+
+      return [];
+    }),
+    headers: {
+      accept: "*/*",
+      "content-type": "application/json",
+      "x-requested-with": "1",
+      cookie: "connect.sid=" + connectSid,
+      origin: "https://replit.com",
+      referer: "https://replit.com/graphql",
+      "user-agent": "Raycast extension",
+    },
+    method: "POST",
+    keepPreviousData: false,
+    body: JSON.stringify({
+      operationName: "TemplateRepls",
+      query: `
+      query TemplateRepls {
+        templateRepls2(options: { count: 500 }) {
+          __typename
+          ... on TemplateReplSearchConnection {
+            category
+            items {
+              ... on Repl {
+                id
+                title
+                description
+                templateCategories {
+                  title
+                  id
+                }
+              }
+            }
+          }
+        }
+      }      
+      `,
+    }),
+  });
+
+  const { data, isLoading } = useAI(`
+    You are helping a user choose a template for a coding project. The user's query is ${searchText}. Respond with an array of relevant options chosen from the following choices, in the format of an object with id and title properties:
+
+    ${JSON.stringify(templatesData)}
+  `, {
+    execute: templatesData && searchText.length > 0,
+  });
+
+  if (templatesError) {
+    return <Detail markdown={`Error: ${templatesError?.message}. ${templatesError}`} />;
+  }
+
+  // console.log(templatesData)
+
+  console.log('response', data, isLoading)
+
+  return (
+    <List onSearchTextChange={setSearchText} throttle>
+      <List.Item title="Hello World" />
+    </List>
+  )
+}

--- a/src/askTemplate.tsx
+++ b/src/askTemplate.tsx
@@ -1,35 +1,32 @@
-import { Detail, List } from "@raycast/api";
+import { Action, ActionPanel, Detail, Icon, Image, List } from "@raycast/api";
 import { useAI, useFetch } from "@raycast/utils";
 import { useEffect, useState } from "react";
 import useCurrentUser from "./hooks/useCurrentUser";
+import { AI_TEMPLATES_STUB_QUERY, SEARCH_TEMPLATES_QUERY } from "./queries";
+import { launchCommand, LaunchType } from "@raycast/api";
 
 export default function Command() {
   const [searchText, setSearchText] = useState("");
   const [searchTerms, setSearchterms] = useState<Array<string>>([]);
 
-  // return <Detail isLoading={isLoading} markdown={data} />;
+  const { connectSid } = useCurrentUser();
 
-  const {connectSid} = useCurrentUser();
-
-
-  const { data: templatesData, isLoading: loadingTemplates, error: templatesError } = useFetch("https://replit.com/graphql", {
-    // execute: searchText.length > 0,
-    parseResponse: (async response => {
+  const {
+    data: templatesData,
+    isLoading: loadingTemplates,
+    error: templatesError,
+  } = useFetch("https://replit.com/graphql", {
+    parseResponse: async (response) => {
       const res = await response.json();
-      // console.log(res);
-
       if (res.data?.templateRepls2?.items) {
-        // console.log(res.data.templateRepls2.items);
         return res.data.templateRepls2.items.map((item: any) => ({
           title: item.title,
-          // id: item.id,
           description: item.description,
-          // categories: item.templateCategories.map((category: any) => category.title),
         }));
       }
 
       return [];
-    }),
+    },
     headers: {
       accept: "*/*",
       "content-type": "application/json",
@@ -40,74 +37,53 @@ export default function Command() {
       "user-agent": "Raycast extension",
     },
     method: "POST",
-    keepPreviousData: false,
+    keepPreviousData: true,
     body: JSON.stringify({
       operationName: "TemplateRepls",
-      query: `
-      query TemplateRepls {
-        templateRepls2(options: { count: 500 }) {
-          __typename
-          ... on TemplateReplSearchConnection {
-            category
-            items {
-              ... on Repl {
-                id
-                title
-                description
-                templateCategories {
-                  title
-                  id
-                }
-              }
-            }
-          }
-        }
-      }      
-      `,
+      query: AI_TEMPLATES_STUB_QUERY,
     }),
   });
 
-  const { data, isLoading } = useAI(`
+  const { data, isLoading } = useAI(
+    `
     You are helping a user choose a template for a coding project. The user's query is ${searchText}. Respond with a valid JSON Javascript array of five relevant search terms that may help the user find the right template according to their query intent. Do not include the word "template" in your suggested terms.
 
     Example response: ["OpenAI", "Chatbot", "Python", "Data Science", "GPT-3"]
 
     You can use the following data to help you identify possible search terms from titles and descriptions. 
     ${JSON.stringify(templatesData)}
-  `, {
-    execute: templatesData && searchText.length > 0,
-    // onData: (d) => {
-    //   console.log('d', d)
-    //   // const parsed = JSON.parse(d);
-    //   // console.log('parsed', parsed);
-    //   // setSearchterms(d);
-    //   return d;
-    // },
-    model: "gpt-3.5-turbo",
-    creativity: 'low',
-    stream: false,
-  });
+  `,
+    {
+      execute: templatesData && searchText.length > 0,
+      model: "gpt-3.5-turbo",
+      creativity: "low",
+      stream: false,
+    }
+  );
 
   useEffect(() => {
     if (data) {
       // console.log(typeof data, JSON.parse(data));
-      setSearchterms(JSON.parse(data))
+      setSearchterms(JSON.parse(data));
     }
-  }, [data])
+  }, [data]);
 
-  const { data: choices, isLoading: loadingchoices, error: choiceserror } = useFetch("https://replit.com/graphql", {
+  const {
+    data: choices,
+    isLoading: loadingchoices,
+    error: choiceserror,
+  } = useFetch("https://replit.com/graphql", {
     execute: searchTerms && searchTerms.length > 1,
-    parseResponse: (async response => {
+    parseResponse: async (response) => {
       const res = await response.json();
       console.log(res);
 
       if (res.data?.search?.templateResults?.results?.items) {
-        // console.log(res.data.templateRepls2.items);
         return res.data.search.templateResults.results.items;
       }
 
       return [];
-    }),
+    },
     headers: {
       accept: "*/*",
       "content-type": "application/json",
@@ -118,35 +94,14 @@ export default function Command() {
       "user-agent": "Raycast extension",
     },
     method: "POST",
-    keepPreviousData: false,
+    keepPreviousData: true,
     body: JSON.stringify({
       operationName: "SearchTemplates",
       variables: {
-        query: searchTerms.join(' '),
+        query: searchTerms.join(" "),
         categories: ["Templates"],
       },
-      query: `
-      query SearchTemplates($query: String!, $categories: [SearchQueryCategory!]!) {
-        search(options: {
-          query: $query,
-          categories: $categories,
-        }) {
-          __typename
-          ... on SearchQueryResults {
-            templateResults {
-              results {
-                items {
-                  id
-                  title
-                  url
-                  description
-                }
-              }
-            }
-          }
-        }
-      }   
-      `,
+      query: SEARCH_TEMPLATES_QUERY,
     }),
   });
 
@@ -154,24 +109,77 @@ export default function Command() {
     return <Detail markdown={`Error: ${templatesError?.message}. ${templatesError}`} />;
   }
 
-  // console.log(templatesData)
-
-  // console.log('response', data, isLoading)
-
   return (
-    <List onSearchTextChange={setSearchText} throttle isLoading={loadingchoices}>
-        {
-          choices?.map((choice: any) => (
-            <List.Item
-              key={choice.id}
-              title={choice.title}
-              subtitle={choice.description}
-              // accessoryTitle={choice.url}
-              // keywords={choice.categories}
-              // icon={{ source: "https://cdn.discordapp.com/attachments/881741662327957771/881741701451374622/unknown.png" }}
+    <List onSearchTextChange={setSearchText} throttle isLoading={loadingchoices} isShowingDetail={!!choices?.length}>
+      {!choices?.length ? (
+        <List.EmptyView
+          title="Ask AI for a Template"
+          description="Describe your project idea and Raycast AI will help you find a relevant template to get started with."
+          icon={Icon.Wand}
+          actions={
+            <ActionPanel>
+              <Action
+                onAction={async () => {
+                  await launchCommand({ name: "index", type: LaunchType.UserInitiated });
+                }}
+                title="Browse Templates"
+              />
+            </ActionPanel>
+          }
+        />
+      ) : null}
+      {choices?.map((choice: any) => (
+        <List.Item
+          icon={{
+            source: choice.iconUrl,
+            mask: Image.Mask.RoundedRectangle,
+          }}
+          key={choice.id}
+          title={choice.title}
+          subtitle={choice.description}
+          detail={
+            <List.Item.Detail
+              markdown={`${choice.description} ${choice.imageUrl ? `![image](${choice.imageUrl})` : ""}`}
+              metadata={
+                <List.Item.Detail.Metadata>
+                  <List.Item.Detail.Metadata.Label
+                    title="Author"
+                    text={choice.user.username}
+                    icon={{ source: choice.user.image, mask: Image.Mask.Circle }}
+                  />
+                  <List.Item.Detail.Metadata.Label
+                    title="Likes"
+                    text={choice.likeCount.toString() + " people liked this Template"}
+                    icon={Icon.Heart}
+                  />
+                  <List.Item.Detail.Metadata.Label
+                    title="Forks"
+                    text={choice.publicForkCount.toString() + " Repls use this Template"}
+                    icon={Icon.Shuffle}
+                  />
+                  {choice.tags == null || !choice.tags.length ? null : (
+                    <List.Item.Detail.Metadata.TagList title="Tags">
+                      {choice.tags.map((tag) => (
+                        <List.Item.Detail.Metadata.TagList.Item text={tag.id} key={tag.id} />
+                      ))}
+                    </List.Item.Detail.Metadata.TagList>
+                  )}
+                </List.Item.Detail.Metadata>
+              }
             />
-          ))
-        }
+          }
+          actions={
+            <ActionPanel>
+              <Action.OpenInBrowser url={`https://replit.com/${choice.url}`} title="Open Cover Page" />
+              <Action.OpenInBrowser
+                title={`Fork Template`}
+                url={`https://replit.com/new?template=${choice.id}`}
+                icon={Icon.Shuffle}
+              />
+            </ActionPanel>
+          }
+        />
+      ))}
     </List>
-  )
+  );
 }

--- a/src/askTemplate.tsx
+++ b/src/askTemplate.tsx
@@ -14,7 +14,6 @@ export default function Command() {
 
   const {
     data: templatesManifest,
-    isLoading: loadingTemplatesManifest,
     error: templatesManifestError,
   } = useFetch("https://replit.com/graphql", {
     parseResponse: parseTemplatesManifestResponse,

--- a/src/askTemplate.tsx
+++ b/src/askTemplate.tsx
@@ -1,10 +1,11 @@
 import { Detail, List } from "@raycast/api";
 import { useAI, useFetch } from "@raycast/utils";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import useCurrentUser from "./hooks/useCurrentUser";
 
 export default function Command() {
   const [searchText, setSearchText] = useState("");
+  const [searchTerms, setSearchterms] = useState<Array<string>>([]);
 
   // return <Detail isLoading={isLoading} markdown={data} />;
 
@@ -15,15 +16,15 @@ export default function Command() {
     // execute: searchText.length > 0,
     parseResponse: (async response => {
       const res = await response.json();
-      console.log(res);
+      // console.log(res);
 
       if (res.data?.templateRepls2?.items) {
-        console.log(res.data.templateRepls2.items);
+        // console.log(res.data.templateRepls2.items);
         return res.data.templateRepls2.items.map((item: any) => ({
           title: item.title,
-          id: item.id,
+          // id: item.id,
           description: item.description,
-          categories: item.templateCategories.map((category: any) => category.title),
+          // categories: item.templateCategories.map((category: any) => category.title),
         }));
       }
 
@@ -67,11 +68,86 @@ export default function Command() {
   });
 
   const { data, isLoading } = useAI(`
-    You are helping a user choose a template for a coding project. The user's query is ${searchText}. Respond with an array of relevant options chosen from the following choices, in the format of an object with id and title properties:
+    You are helping a user choose a template for a coding project. The user's query is ${searchText}. Respond with a valid JSON Javascript array of five relevant search terms that may help the user find the right template according to their query intent. Do not include the word "template" in your suggested terms.
 
+    Example response: ["OpenAI", "Chatbot", "Python", "Data Science", "GPT-3"]
+
+    You can use the following data to help you identify possible search terms from titles and descriptions. 
     ${JSON.stringify(templatesData)}
   `, {
     execute: templatesData && searchText.length > 0,
+    // onData: (d) => {
+    //   console.log('d', d)
+    //   // const parsed = JSON.parse(d);
+    //   // console.log('parsed', parsed);
+    //   // setSearchterms(d);
+    //   return d;
+    // },
+    model: "gpt-3.5-turbo",
+    creativity: 'low',
+    stream: false,
+  });
+
+  useEffect(() => {
+    if (data) {
+      // console.log(typeof data, JSON.parse(data));
+      setSearchterms(JSON.parse(data))
+    }
+  }, [data])
+
+  const { data: choices, isLoading: loadingchoices, error: choiceserror } = useFetch("https://replit.com/graphql", {
+    execute: searchTerms && searchTerms.length > 1,
+    parseResponse: (async response => {
+      const res = await response.json();
+      console.log(res);
+
+      if (res.data?.search?.templateResults?.results?.items) {
+        // console.log(res.data.templateRepls2.items);
+        return res.data.search.templateResults.results.items;
+      }
+
+      return [];
+    }),
+    headers: {
+      accept: "*/*",
+      "content-type": "application/json",
+      "x-requested-with": "1",
+      cookie: "connect.sid=" + connectSid,
+      origin: "https://replit.com",
+      referer: "https://replit.com/graphql",
+      "user-agent": "Raycast extension",
+    },
+    method: "POST",
+    keepPreviousData: false,
+    body: JSON.stringify({
+      operationName: "SearchTemplates",
+      variables: {
+        query: searchTerms.join(' '),
+        categories: ["Templates"],
+      },
+      query: `
+      query SearchTemplates($query: String!, $categories: [SearchQueryCategory!]!) {
+        search(options: {
+          query: $query,
+          categories: $categories,
+        }) {
+          __typename
+          ... on SearchQueryResults {
+            templateResults {
+              results {
+                items {
+                  id
+                  title
+                  url
+                  description
+                }
+              }
+            }
+          }
+        }
+      }   
+      `,
+    }),
   });
 
   if (templatesError) {
@@ -80,11 +156,22 @@ export default function Command() {
 
   // console.log(templatesData)
 
-  console.log('response', data, isLoading)
+  // console.log('response', data, isLoading)
 
   return (
-    <List onSearchTextChange={setSearchText} throttle>
-      <List.Item title="Hello World" />
+    <List onSearchTextChange={setSearchText} throttle isLoading={loadingchoices}>
+        {
+          choices?.map((choice: any) => (
+            <List.Item
+              key={choice.id}
+              title={choice.title}
+              subtitle={choice.description}
+              // accessoryTitle={choice.url}
+              // keywords={choice.categories}
+              // icon={{ source: "https://cdn.discordapp.com/attachments/881741662327957771/881741701451374622/unknown.png" }}
+            />
+          ))
+        }
     </List>
   )
 }

--- a/src/askTemplate.tsx
+++ b/src/askTemplate.tsx
@@ -41,11 +41,12 @@ export default function Command() {
     error: keywordResponseError,
   } = useAI(
     `
-    You are helping a user choose a template for a coding project. The user's query is ${searchText}. Respond with a valid JSON Javascript array of five relevant search terms that may help the user find the right template according to their query intent. Do not include the word "template" in your suggested terms.
-
+    Your goal is to help a user choose a Replit template for a coding project. You need to infer keywords relating to their intent and the possible technologies it can be built with. Respond with a valid JSON Javascript array of five relevant search terms that may help the user find the right template according to their query intent. Do not include the word "template" in your suggested terms.
+    
+    Project idea: ${searchText}.
     Example response: ["OpenAI", "Chatbot", "Python", "Data Science", "GPT-3"]
 
-    You can use the following data to help you identify possible search terms from titles and descriptions. 
+    The following data can be used to help you, but feel free to use any other keywords you think are relevant that are not included here:
     ${JSON.stringify(templatesManifest)}
   `,
     {
@@ -58,7 +59,12 @@ export default function Command() {
 
   useEffect(() => {
     if (keywordResponse) {
-      setSearchterms(JSON.parse(keywordResponse));
+      try {
+        const json = JSON.parse(keywordResponse)
+        setSearchterms(json);
+      } catch (e) {
+        console.log(e);
+      }
     }
   }, [keywordResponse]);
 
@@ -223,7 +229,7 @@ const parseTemplateResultsResponse = async (response: Response) => {
   if (res.data?.search?.templateResults?.results?.items) {
     // Sort the results by fork count
     return res.data.search.templateResults.results.items.sort(
-      (a: TemplateRepl, b: TemplateRepl) => b.publicForkCount - a.publicForkCount
+      (a: TemplateRepl, b: TemplateRepl) => b.likeCount - a.likeCount
     );
   }
 

--- a/src/askTemplate.tsx
+++ b/src/askTemplate.tsx
@@ -155,7 +155,7 @@ export default function Command() {
           }
         />
       ) : null}
-      {templateResults?.map((choice: any) => (
+      {templateResults?.map((choice: TemplateRepl) => (
         <List.Item
           icon={{
             source: choice.iconUrl,

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -86,4 +86,60 @@ query ReplSearch($q: String!, $ownerId: Int!) {
     }
   }
 }
-`
+`;
+
+// AI queries
+export const AI_TEMPLATES_STUB_QUERY = `
+  query TemplateRepls {
+    templateRepls2(options: { count: 500 }) {
+      __typename
+      ... on TemplateReplSearchConnection {
+        category
+        items {
+          ... on Repl {
+            title
+            description
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const SEARCH_TEMPLATES_QUERY = `
+  query SearchTemplates($query: String!, $categories: [SearchQueryCategory!]!) {
+    search(options: {
+      query: $query,
+      categories: $categories,
+    }) {
+      __typename
+      ... on SearchQueryResults {
+        templateResults {
+          results {
+            items {
+              id
+          title
+          imageUrl
+          description
+          iconUrl
+          tags {
+            id
+          }
+          likeCount
+          url
+          publicForkCount
+          templateCategories {
+            title
+            id
+          }
+          user {
+            username
+            image
+          }
+            }
+          }
+        }
+      }
+    }
+  }   
+  `

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -107,10 +107,15 @@ export const AI_TEMPLATES_STUB_QUERY = `
 `;
 
 export const SEARCH_TEMPLATES_QUERY = `
-  query SearchTemplates($query: String!, $categories: [SearchQueryCategory!]!) {
+  query SearchTemplates($query: String!, $categories: [SearchQueryCategory!]!, $status: SearchQueryTemplateStatus!) {
     search(options: {
       query: $query,
       categories: $categories,
+      categorySettings: {
+        templates: {
+          status: $status
+        }
+      }
     }) {
       __typename
       ... on SearchQueryResults {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,12 @@ export type TemplateCategory = {
   description: string;
 };
 
+export enum TemplateStatus {
+  All = "All",
+  Official = "Official",
+  Community = "Community",
+}
+
 // results of the categories graphql query
 export type TemplateCategoriesResults = {
   templateCategories: {
@@ -46,7 +52,7 @@ export type TemplateReplsForCategory = {
 };
 
 // a single search result
-export interface SearchResult {
+export type SearchResult = {
   title: string;
   description: string;
   iconUrl: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -130,17 +130,17 @@
     "@typescript-eslint/utils" "^5.48.1"
     title-case "^3.0.3"
 
-"@raycast/utils@^1.5.2":
-  version "1.5.2"
-  resolved "https://registry.npmjs.org/@raycast/utils/-/utils-1.5.2.tgz"
-  integrity sha512-poi+/HeLsTrSyA4NOaXAzLJJJl6oxPpRV9lSEBwSSR/Fa6bmtdxykmBtQpYqbSUgGlosrqzzgniaTU/LdwHh+A==
+"@raycast/utils@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@raycast/utils/-/utils-1.7.0.tgz#25df686b9b02685da523eb17b81385d8147c698b"
+  integrity sha512-s3gT8CGQHRln0CQSaLuChOze0fygsWeCRIkbm67F4q5PLAsA6NTT48WtXmzbDQa6Q1S4IOqTTLGAteggW0CQ8w==
   dependencies:
     content-type "^1.0.5"
-    cross-fetch "^3.1.5"
+    cross-fetch "^3.1.6"
     dequal "^2.0.3"
     media-typer "^1.1.0"
     object-hash "^3.0.0"
-    signal-exit "^3.0.7"
+    signal-exit "^4.0.2"
 
 "@rushstack/eslint-patch@^1.2.0":
   version "1.3.0"
@@ -604,12 +604,12 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
-cross-fetch@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz"
-  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+cross-fetch@^3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.6.tgz#bae05aa31a4da760969756318feeee6e70f15d6c"
+  integrity sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==
   dependencies:
-    node-fetch "2.6.7"
+    node-fetch "^2.6.11"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -1521,10 +1521,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-node-fetch@2.6.7:
-  version "2.6.7"
-  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+node-fetch@^2.6.11:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.11.tgz#cde7fc71deef3131ef80a738919f999e6edfff25"
+  integrity sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -1910,10 +1910,15 @@ shell-quote@^1.6.1:
   resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz"
   integrity sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==
 
-signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.7:
+signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.7"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
+
+signal-exit@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.0.2.tgz#ff55bb1d9ff2114c13b400688fa544ac63c36967"
+  integrity sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==
 
 slash@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Adds a new command, "AI Template Suggestion", which suggests templates based on a natural language query, e.g. a project idea.

Here's how it works:
1. `useAI()` has a preamble prompt that integrates all our template titles and descriptions as context.
2. It then infers search intent and returns an array of 5 keywords (as a string).
3. After `JSON.parse()` on the keyword string, we search the templates endpoint using the keywords.
4. Finally, we render the suggested templates in a List view.

There are a few additional features:
- Users can select All, Official, or Community templates. Official templates are shown by default.
- Results are sorted by repl like count.
- Users can fork the template as the default action.
- Users can also open the cover page via an action.