### PR TITLE
Switched to another query that includes multiplayer repls

### DIFF
--- a/src/findRepl.tsx
+++ b/src/findRepl.tsx
@@ -50,18 +50,23 @@ export default function Command() {
       ) : null}
       <List.Section title="Your Repls" subtitle={data?.length + ""}>
         {data?.map((searchResult) => (
-          <SearchListItem key={searchResult.title} searchResult={searchResult} />
+          <SearchListItem key={searchResult.title} searchResult={searchResult} currentUserId={userId} />
         ))}
       </List.Section>
     </List>
   );
 }
 
-function SearchListItem({ searchResult }: { searchResult: SearchResult }) {
-  console.log(searchResult);
+function SearchListItem({ searchResult, currentUserId }: { searchResult: SearchResult; currentUserId: number | null }) {
+  let title = searchResult.title;
+
+  if (currentUserId !== searchResult.owner.id) {
+    title = `@${searchResult.owner.username}/${title}`;
+  }
+
   return (
     <List.Item
-      title={searchResult.title}
+      title={title}
       subtitle={searchResult.description}
       icon={{ source: searchResult.iconUrl, mask: Image.Mask.RoundedRectangle }}
       accessories={[
@@ -69,11 +74,11 @@ function SearchListItem({ searchResult }: { searchResult: SearchResult }) {
           ? {
               tag: {
                 value: "Always On",
-                color: Color.Green
-              }
+                color: Color.Green,
+              },
             }
           : {},
-        searchResult.isPrivate ? { icon: Icon.Lock } : {icon: Icon.Globe, tooltip: "Public Repl"},
+        searchResult.isPrivate ? { icon: Icon.Lock } : { icon: Icon.Globe, tooltip: "Public Repl" },
       ]}
       actions={
         <ActionPanel>
@@ -110,10 +115,9 @@ function SearchListItem({ searchResult }: { searchResult: SearchResult }) {
 /** Parse the response from the fetch query into something we can display */
 export async function parseFetchResponse(response: Response): Promise<SearchResult[]> {
   const res = await response.json();
-  console.log(res);
 
-  if (res?.data?.search?.replResults?.results?.items) {
-    return res.data.search.replResults.results.items.map((item: SearchResult) => item);
+  if (res?.data?.currentUser?.search?.repls) {
+    return res?.data?.currentUser?.search?.repls.map((item: SearchResult) => item);
   }
 
   return [];

--- a/src/findRepl.tsx
+++ b/src/findRepl.tsx
@@ -58,11 +58,7 @@ export default function Command() {
 }
 
 function SearchListItem({ searchResult, currentUserId }: { searchResult: SearchResult; currentUserId: number | null }) {
-  let title = searchResult.title;
-
-  if (currentUserId !== searchResult.owner.id) {
-    title = `@${searchResult.owner.username}/${title}`;
-  }
+  const title = searchResult.title;
 
   return (
     <List.Item
@@ -75,6 +71,14 @@ function SearchListItem({ searchResult, currentUserId }: { searchResult: SearchR
               tag: {
                 value: "Always On",
                 color: Color.Green,
+              },
+            }
+          : {},
+        currentUserId !== searchResult.owner.id
+          ? {
+              tag: {
+                value: "@" + searchResult.owner.username,
+                color: Color.Orange,
               },
             }
           : {},

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -56,32 +56,32 @@ export const TEMPLATES_QUERY = (category: number | null) => {
 };
 
 export const FIND_REPLS_QUERY = `
-query ReplSearch($q: String!, $ownerId: Int!) {
-  search(
-    options: {
-      categories: Repls
-      query: $q
-      categorySettings: { repls: { ownerId: $ownerId } }
-    }
-  ) {
-    __typename
-    ... on UnauthorizedError {
-      message
-    }
-    ... on SearchQueryResults {
-      replResults {
-        results {
-          items {
+query ReplSearch($q: String!) {
+  currentUser {
+    id
+    search {
+      repls(query: $q, count: 10) {
+        id
+        title
+        slug
+        description
+        isAlwaysOn
+        isPrivate
+        iconUrl
+        url
+        inviteUrl
+        analyticsUrl
+        owner {
+          ... on User {
             id
-            title
-            slug
-            description
-            isAlwaysOn
-            isPrivate
-            iconUrl
-            url
-            inviteUrl
-            analyticsUrl
+            username
+            image
+            fullName
+          }
+          ... on Team {
+            id
+            username
+            image
           }
         }
       }
@@ -149,4 +149,4 @@ export const SEARCH_TEMPLATES_QUERY = `
       }
     }
   }   
-  `
+  `;

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -60,7 +60,7 @@ query ReplSearch($q: String!) {
   currentUser {
     id
     search {
-      repls(query: $q, count: 10) {
+      repls(query: $q, count: 20) {
         id
         title
         slug

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -61,7 +61,11 @@ export type SearchResult = {
   analyticsUrl: string;
   isAlwaysOn: boolean;
   isPrivate: boolean;
-}
+  owner: {
+    id: number;
+    username: string;
+  };
+};
 
 export type SearchResultsResult = {
   data: {
@@ -71,6 +75,6 @@ export type SearchResultsResult = {
           items: SearchResult[];
         };
       };
-    }
-  }
-}
+    };
+  };
+};


### PR DESCRIPTION
The query we were using was the sitewide search query that isn't meant to be personalized for the user. We were filtering by userId but a lot of the repls users care about do not belong to them (they belong to a collaborator or a team!)

So I switched to the query that powers our home page command bar search

Now it shows all repls I have access to. The creator's username is appended if the creator isn't the logged in user. (alternatively we can show them in a separate section. ideally i'd like to render the title in grayscale, it's a bit of a pain when there's a lot of results, especially from teams)

<img width="777" alt="Screenshot 2023-05-28 at 04 33 25" src="https://github.com/devinhalladay/replit-raycast/assets/6189367/96a2263e-560c-44b6-9d05-0c0f61a78ee8">

 Beyond this, I think we should iterate on quality / relevance of results internally